### PR TITLE
Add chart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # my-first-code
-첫 저장소
+
+간단한 예제 파일 모음입니다.
+
+## Chart.js 예제
+`chart.html`을 브라우저에서 열면 막대그래프가 그려집니다.
+
+## matplotlib 예제
+`python_chart.py`를 실행하면 `sales_chart.png` 파일이 생성됩니다.
+
+```bash
+python3 python_chart.py
+```

--- a/chart.html
+++ b/chart.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Chart.js Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        #chart-container { width: 600px; height: 400px; margin: 0 auto; }
+    </style>
+</head>
+<body>
+<div id="chart-container">
+    <canvas id="myChart"></canvas>
+</div>
+<script>
+const ctx = document.getElementById('myChart').getContext('2d');
+const myChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+        datasets: [{
+            label: 'Sales',
+            data: [12, 19, 3, 5, 2, 3],
+            backgroundColor: 'rgba(75, 192, 192, 0.6)'
+        }]
+    },
+    options: {
+        scales: {
+            y: { beginAtZero: true }
+        }
+    }
+});
+</script>
+</body>
+</html>

--- a/python_chart.py
+++ b/python_chart.py
@@ -1,0 +1,13 @@
+import matplotlib.pyplot as plt
+
+months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']
+values = [12, 19, 3, 5, 2, 3]
+
+plt.figure(figsize=(6, 4))
+plt.bar(months, values, color='skyblue')
+plt.title('Sales')
+plt.xlabel('Month')
+plt.ylabel('Value')
+plt.tight_layout()
+plt.savefig('sales_chart.png')
+print("Chart saved to sales_chart.png")


### PR DESCRIPTION
## Summary
- add a Chart.js example HTML file
- add a matplotlib example Python script
- expand README with instructions

## Testing
- `python3 python_chart.py`


------
https://chatgpt.com/codex/tasks/task_e_6841290f6190832093a13c98ef3ad5fa