### PR TITLE
Add minimal bootloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+boot.bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+boot.bin: boot.asm
+	nasm -f bin boot.asm -o boot.bin
+
+clean:
+	rm -f boot.bin
+
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # my-first-code
 첫 저장소
+
+## Simple Bootloader
+
+This repository includes a tiny boot sector written in assembly. It prints
+"Hello, world!" when executed in a PC emulator.
+
+### Building
+
+```
+make boot.bin
+```
+
+This uses `nasm` to assemble `boot.asm` into `boot.bin`.
+
+### Running (with QEMU)
+
+```
+qemu-system-x86_64 -drive format=raw,file=boot.bin
+```
+
+This requires `qemu-system-x86_64` to be installed.

--- a/boot.asm
+++ b/boot.asm
@@ -1,0 +1,22 @@
+[org 0x7c00]
+    mov si, message
+print_loop:
+    lodsb
+    or al, al
+    jz halt
+    mov ah, 0x0e
+    mov bh, 0x00
+    mov bl, 0x07
+    int 0x10
+    jmp print_loop
+
+halt:
+    cli
+hang:
+    hlt
+    jmp hang
+
+message db 'Hello, world!', 0
+
+times 510-($-$$) db 0
+dw 0xaa55


### PR DESCRIPTION
## Summary
- implement a tiny x86 boot sector that prints `Hello, world!`
- provide a Makefile for building `boot.bin`
- document build and run steps in the README
- ignore generated binary

## Testing
- `make boot.bin`

------
https://chatgpt.com/codex/tasks/task_e_6858f675278483209fe3ff7195e20194